### PR TITLE
Fix ansible inventory path

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
-inventory = inventories/dynamic_ec2.yml
+inventory = inventories/aws_ec2.yml
 host_key_checking = False
 retry_files_enabled = False


### PR DESCRIPTION
## Summary
- set Ansible inventory to `inventories/aws_ec2.yml`

## Testing
- `ansible-playbook --syntax-check ansible/playbooks/update_hello.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a47cae53c832da0f120d3b629b8a2